### PR TITLE
feat: Clickable schedule matchups open Head-to-Head comparison

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -46,6 +46,7 @@ export default function App() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [currentView, setCurrentView] = useState("schedule");
+  const [h2hTeams, setH2hTeams] = useState({ a: "", b: "" });
   const [selectedWeek, setSelectedWeek] = useState(null);
   const [selectedTeam, setSelectedTeam] = useState(null);
 
@@ -171,11 +172,20 @@ export default function App() {
         {currentView === "bowlers" && <BowlerTable {...viewProps} />}
         {currentView === "improved" && <MostImproved {...viewProps} />}
         {currentView === "trends" && <WeekTrends {...viewProps} />}
-        {currentView === "h2h" && <HeadToHead {...viewProps} />}
+        {currentView === "h2h" && (
+          <HeadToHead
+            {...viewProps}
+            initialTeamA={h2hTeams.a}
+            initialTeamB={h2hTeams.b}
+          />
+        )}
         {currentView === "schedule" && (
           <Schedule
-            currentWeek={data?.meta?.currentWeek}
             schedule={data?.meta?.schedule}
+            onMatchupClick={(a, b) => {
+              setH2hTeams({ a, b });
+              setCurrentView("h2h");
+            }}
           />
         )}
       </main>

--- a/src/views/HeadToHead.jsx
+++ b/src/views/HeadToHead.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import { computeTeams } from '../utils/dataUtils.js'
 import { RadarChart, Radar, PolarGrid, PolarAngleAxis, ResponsiveContainer, Tooltip } from 'recharts'
 
@@ -21,9 +21,13 @@ function StatRow({ label, aVal, bVal, higherIsBetter = true }) {
   )
 }
 
-export default function HeadToHead({ weekData }) {
-  const [teamA, setTeamA] = useState('')
-  const [teamB, setTeamB] = useState('')
+export default function HeadToHead({ weekData, initialTeamA = '', initialTeamB = '' }) {
+  const [teamA, setTeamA] = useState(initialTeamA)
+  const [teamB, setTeamB] = useState(initialTeamB)
+
+  // Sync when pre-selected teams arrive from Schedule view
+  useEffect(() => { if (initialTeamA) setTeamA(initialTeamA) }, [initialTeamA])
+  useEffect(() => { if (initialTeamB) setTeamB(initialTeamB) }, [initialTeamB])
 
   if (!weekData) return <p className="text-gray-500">No data.</p>
 
@@ -136,14 +140,20 @@ export default function HeadToHead({ weekData }) {
             {[{ team: tA, color: 'text-amber-400', bgBorder: 'border-amber-700/30' },
               { team: tB, color: 'text-blue-400',  bgBorder: 'border-blue-700/30'  }].map(({ team, color, bgBorder }) => (
               <div key={team.TeamID} className={`bg-alley-700 rounded-lg border ${bgBorder} p-4`}>
-                <h4 className={`font-ui font-800 ${color} uppercase tracking-wider text-sm mb-3`}>{team.TeamName} Roster</h4>
+                <h4 className={`font-ui font-800 ${color} uppercase tracking-wider text-sm mb-2`}>{team.TeamName} Roster</h4>
+                <div className="grid grid-cols-3 text-xs text-zinc-600 uppercase tracking-wider pb-1 border-b border-white/[0.06] mb-1 gap-2">
+                  <span>Name</span>
+                  <span className="text-center">Avg</span>
+                  <span className="text-right">Hcp</span>
+                </div>
                 {[...team.bowlers]
                   .filter(b => b.TotalGames > 0)
                   .sort((a, b) => b.Average - a.Average)
                   .map(b => (
-                    <div key={b.BowlerID} className="flex justify-between py-1 border-b border-white/[0.04] last:border-0 text-xs">
-                      <span className="font-ui text-gray-300">{b.BowlerName}</span>
-                      <span className="font-mono text-gray-400">{b.Average} avg</span>
+                    <div key={b.BowlerID} className="grid grid-cols-3 items-center py-1.5 border-b border-white/[0.04] last:border-0 text-xs gap-2">
+                      <span className="font-ui text-gray-300 truncate col-span-1">{b.BowlerName.includes(',') ? b.BowlerName.split(', ').reverse().join(' ') : b.BowlerName}</span>
+                      <span className="font-mono text-center text-gray-300 font-bold">{b.Average}</span>
+                      <span className="font-mono text-right text-zinc-500">+{b.HandicapAfterBowling} hcp</span>
                     </div>
                   ))}
               </div>

--- a/src/views/Schedule.jsx
+++ b/src/views/Schedule.jsx
@@ -61,18 +61,25 @@ function getActiveWeekNum(schedule) {
   return schedule[schedule.length - 1].week;
 }
 
-function MatchupCard({ t1, t2, laneLabel, isCurrentWeek }) {
+function MatchupCard({ t1, t2, laneLabel, isCurrentWeek, onClick }) {
   return (
-    <div className={`flex flex-col gap-1 rounded-lg px-3 py-2.5 ${
-      isCurrentWeek
-        ? "bg-amber-500/10 border border-amber-500/30"
-        : "bg-zinc-800/70 border border-zinc-700/50"
-    }`}>
-      <div
-        className={`text-sm font-black tracking-widest mb-1 ${isCurrentWeek ? "text-amber-500" : "text-zinc-300"}`}
-        style={{ fontFamily: "'Share Tech Mono', monospace" }}
-      >
-        LANES {laneLabel}
+    <div
+      onClick={onClick}
+      title="View Head-to-Head"
+      className={`flex flex-col gap-1 rounded-lg px-3 py-2.5 cursor-pointer transition-all ${
+        isCurrentWeek
+          ? "bg-amber-500/10 border border-amber-500/30 hover:bg-amber-500/20 hover:border-amber-400 hover:shadow-lg hover:shadow-amber-500/10"
+          : "bg-zinc-800/70 border border-zinc-700/50 hover:bg-zinc-700/60 hover:border-zinc-500"
+      }`}
+    >
+      <div className="flex items-center justify-between mb-1">
+        <div
+          className={`text-sm font-black tracking-widest ${isCurrentWeek ? "text-amber-500" : "text-zinc-300"}`}
+          style={{ fontFamily: "'Share Tech Mono', monospace" }}
+        >
+          LANES {laneLabel}
+        </div>
+        <div className="text-xs text-zinc-600 group-hover:text-zinc-400">⚔️</div>
       </div>
       <div className="flex items-center gap-2">
         <div className="flex-1 min-w-0">
@@ -96,7 +103,7 @@ function MatchupCard({ t1, t2, laneLabel, isCurrentWeek }) {
   );
 }
 
-export default function Schedule({ schedule: scheduleProp }) {
+export default function Schedule({ schedule: scheduleProp, onMatchupClick }) {
   // Use live data from data.json if synced, otherwise use the hardcoded verified schedule
   const schedule = (scheduleProp?.length >= 19) ? scheduleProp : SCHEDULE;
 
@@ -203,11 +210,21 @@ export default function Schedule({ schedule: scheduleProp }) {
           )}
 
           {selected.matchups && (
-            <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
-              {selected.matchups.map(([t1, t2], i) => (
-                <MatchupCard key={i} t1={t1} t2={t2} laneLabel={LANE_PAIRS[i]} isCurrentWeek={selected.week === activeWeekNum} />
-              ))}
-            </div>
+            <>
+              <p className="text-xs text-zinc-600 text-right -mb-1">tap a matchup to compare ⚔️</p>
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                {selected.matchups.map(([t1, t2], i) => (
+                  <MatchupCard
+                    key={i}
+                    t1={t1}
+                    t2={t2}
+                    laneLabel={LANE_PAIRS[i]}
+                    isCurrentWeek={selected.week === activeWeekNum}
+                    onClick={() => onMatchupClick(TEAMS[t1] ?? `Team ${t1}`, TEAMS[t2] ?? `Team ${t2}`)}
+                  />
+                ))}
+              </div>
+            </>
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary
Tapping any lane matchup card in the Schedule view now navigates directly to the Head-to-Head view with both teams pre-loaded — no manual selection needed.

## Changes
- **Schedule.jsx** — matchup cards are clickable with hover states and `onMatchupClick` callback
- **HeadToHead.jsx** — accepts `initialTeamA` / `initialTeamB` props, synced via `useEffect`; roster now shows Name · Avg · Handicap
- **App.jsx** — `h2hTeams` state bridges Schedule → HeadToHead navigation

Closes #10